### PR TITLE
Fix NameError in cogs.stats extension by importing os module

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -1,3 +1,4 @@
+import os
 import discord
 from discord.ext import commands
 import config


### PR DESCRIPTION
Add import statement for os module in cogs/stats.py

* Import os module at the beginning of the file to fix the NameError: name 'os' is not defined error in the cogs.stats extension.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/xenycx/DiscordTTCBOT/pull/4?shareId=c25595bc-e91c-4fe7-b531-8c60e3e47c31).